### PR TITLE
feat: support New client with explicit params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# IDE specific files
+.idea/

--- a/internal/pkg/api/client.go
+++ b/internal/pkg/api/client.go
@@ -17,16 +17,23 @@ type Client struct {
 	restClient *restclientgo.RestClient
 }
 
+// New creates a new Langfuse client with the environment variables:
+// LANGFUSE_HOST, LANGFUSE_PUBLIC_KEY, and LANGFUSE_SECRET_KEY.
 func New() *Client {
 	langfuseHost := os.Getenv("LANGFUSE_HOST")
-	if langfuseHost == "" {
-		langfuseHost = langfuseDefaultEndpoint
-	}
-
 	publicKey := os.Getenv("LANGFUSE_PUBLIC_KEY")
 	secretKey := os.Getenv("LANGFUSE_SECRET_KEY")
+	return NewWithParams(langfuseHost, publicKey, secretKey)
 
-	restClient := restclientgo.New(langfuseHost)
+}
+
+// NewWithParams creates a new Langfuse client with the specified endpoint, public key, and secret key.
+// If the endpoint is empty, it defaults to the Langfuse cloud endpoint.
+func NewWithParams(endpoint, publicKey, secretKey string) *Client {
+	if endpoint == "" {
+		endpoint = langfuseDefaultEndpoint
+	}
+	restClient := restclientgo.New(endpoint)
 	restClient.SetRequestModifier(func(req *http.Request) *http.Request {
 		req.Header.Set("Authorization", basicAuth(publicKey, secretKey))
 		return req

--- a/internal/pkg/api/request.go
+++ b/internal/pkg/api/request.go
@@ -12,8 +12,6 @@ const (
 	ContentTypeJSON = "application/json"
 )
 
-type Request struct{}
-
 type Ingestion struct {
 	Batch []model.IngestionEvent `json:"batch"`
 }


### PR DESCRIPTION
Currently, the users of this library need to set the required parameters (like public/private kies) as the env variable in code. With this commit, something like this:
```go
	err := os.Setenv("LANGFUSE_HOST", baseURL)
	if err != nil {
		return nil, fmt.Errorf("failed to set LANGFUSE_HOST: %w", err)
	}
	err = os.Setenv("LANGFUSE_PUBLIC_KEY", publicKey)
	if err != nil {
		return nil, fmt.Errorf("failed to set LANGFUSE_PUBLIC_KEY: %w", err)
	}
	err = os.Setenv("LANGFUSE_SECRET_KEY", secretKey)
	if err != nil {
		return nil, fmt.Errorf("failed to set LANGFUSE_SECRET_KEY: %w", err)
	}
	client := langfuse.New(ctx)
```
can be done much more simpler; like below:
```go
	client := langfuse.NewWithEndpoint(baseURL, publicKey, secretKey)
```

The previous behavior is remained unchanged, for backward-compatibilty.